### PR TITLE
Fix CVE-2025-64756: Update glob

### DIFF
--- a/.github/wolf-todos/CVE-2025-64756.md
+++ b/.github/wolf-todos/CVE-2025-64756.md
@@ -1,0 +1,10 @@
+# Fix CVE-2025-64756
+
+Package: glob
+Severity: high
+Patched versions: See advisory
+
+## TODO
+- [ ] Update package-lock.json
+- [ ] Test changes
+- [ ] Verify security fix


### PR DESCRIPTION
## 🤖 Dependabot Wolf - Automated Fix Attempt

**CVE:** CVE-2025-64756
**Severity:** high
**Package:** glob
**Current Version:** package-lock.json specifies a vulnerable version
**Patched Versions:** See advisory
**Advisory URL:** undefined

### Problem
Dependabot could not automatically create a PR to fix this vulnerability, likely due to dependency conflicts.

### Task for Copilot
Please analyze the dependency tree and propose a fix:

1. Identify why the direct upgrade failed (check transitive dependencies)
2. Update `package-lock.json` with necessary version changes
3. If breaking changes are needed, update calling code
4. Explain your changes

@github-copilot workspace